### PR TITLE
Update start_interpolation naming for 1.19.4-rc1

### DIFF
--- a/data/mcanim/functions/display_animations/generic/init.mcfunction
+++ b/data/mcanim/functions/display_animations/generic/init.mcfunction
@@ -1,4 +1,4 @@
 data modify entity @s interpolation_duration set from storage mcanim:api/display_animation/generic animation.duration
 execute unless data storage mcanim:api/display_animation/generic animation.duration run data modify entity @s interpolation_duration set from storage mcanim:api/display_animation/generic default_duration
 data modify entity @s {} merge from storage mcanim:api/display_animation/generic animation
-data modify entity @s interpolation_start set value -1
+data modify entity @s start_interpolation set value -1

--- a/data/mcanim/functions/display_animations/rotate/left.mcfunction
+++ b/data/mcanim/functions/display_animations/rotate/left.mcfunction
@@ -6,6 +6,6 @@ function mcanim:api/maths/xyz_to_quaternion
 
 data modify entity @s transformation.left_rotation set from storage mcanim:api/maths/xyz_to_quaternion output
 
-data modify entity @s interpolation_start set value -1
+data modify entity @s start_interpolation set value -1
 
 data remove storage mcanim:api/display_animation/rotate animation

--- a/data/mcanim/functions/display_animations/rotate/right.mcfunction
+++ b/data/mcanim/functions/display_animations/rotate/right.mcfunction
@@ -6,4 +6,4 @@ execute store result entity @s transformation.right_rotation[0] float 0.001 run 
 execute store result entity @s transformation.right_rotation[1] float 0.001 run scoreboard players get .j mcanim.display_animations.rotate
 execute store result entity @s transformation.right_rotation[2] float 0.001 run scoreboard players get .k mcanim.display_animations.rotate
 execute store result entity @s transformation.right_rotation[3] float 0.001 run scoreboard players get .extra mcanim.display_animations.rotate
-data modify entity @s interpolation_start set value -1
+data modify entity @s start_interpolation set value -1

--- a/data/mcanim/functions/display_animations/scale/init.mcfunction
+++ b/data/mcanim/functions/display_animations/scale/init.mcfunction
@@ -3,4 +3,4 @@ execute unless data storage mcanim:api/display_animation/scale animation.duratio
 execute store result entity @s transformation.scale[0] float 1 run data get storage mcanim:api/display_animation/scale animation.x
 execute store result entity @s transformation.scale[1] float 1 run data get storage mcanim:api/display_animation/scale animation.y
 execute store result entity @s transformation.scale[2] float 1 run data get storage mcanim:api/display_animation/scale animation.z
-data modify entity @s interpolation_start set value -1
+data modify entity @s start_interpolation set value -1

--- a/data/mcanim/functions/display_animations/translate/init.mcfunction
+++ b/data/mcanim/functions/display_animations/translate/init.mcfunction
@@ -3,4 +3,4 @@ execute unless data storage mcanim:api/display_animation/translate animation.dur
 execute store result entity @s transformation.translation[0] float 1 run data get storage mcanim:api/display_animation/translate animation.x
 execute store result entity @s transformation.translation[1] float 1 run data get storage mcanim:api/display_animation/translate animation.y
 execute store result entity @s transformation.translation[2] float 1 run data get storage mcanim:api/display_animation/translate animation.z
-data modify entity @s interpolation_start set value -1
+data modify entity @s start_interpolation set value -1


### PR DESCRIPTION
In Minecraft 1.19.4-rc1, `interpolation_start` was replaced with `start_interpolation`

This causes the display entities to jump suddenly instead of animating smoothly.
Renaming it fixed the issue.

It seems the behavior has changed a bit in addition to being renamed, which may be worth keeping in mind in case any future bugs pop up:
![image](https://user-images.githubusercontent.com/6022168/231046926-3b8f00ce-c658-4fc3-8689-7690804ff2ac.png)
(Source: https://minecraft.fandom.com/wiki/Display#History)

Here are the commands I used to test it (using Minecraft 23w14a):

```mcfunction
execute summon minecraft:block_display run data merge entity @s {block_state: {Name: "minecraft:pink_concrete"} }
data modify storage mcanim:api/display_animation/translate animation set value {duration: 100, x: 0, y: 5, z: 0}
execute as @e[type=block_display] run function mcanim:api/display_animations/translate
```